### PR TITLE
Add proxy key verification to token-server

### DIFF
--- a/lib/token-server.js
+++ b/lib/token-server.js
@@ -1,13 +1,29 @@
 var tls = require('net'),       // TODO: provide tls certificate (or convert to http and let nginx secure…)
     util = require('util'),
     csig = require('cookie-signature'),
-    config = require("./config.js");
+    config = require("./config.js"),
+    qs = require('querystring'),
+    http = require('http');
 
 function checkCredentials(creds, cb) {
-  // TODO: verify with auth server (i.e. do credentials merit a proxy token?)
   setImmediate(function () {
-      if (creds === 'DEV-CRED') cb((Math.random() > 0.9) ? new Error("Chaos monkeyed!") : null, true);
-      else cb(null, false);
+    var params = qs.stringify({
+      proxySecret: process.env.PROXY_SECRET,
+      proxyKey: creds
+    });
+    http.get({
+      hostname: process.env.PROXY_HOST,
+      port: process.env.PROXY_PORT,
+      path: '/proxy/verify?'+params
+    }, function(res){
+      res.on('data', function(d){
+        if(!d.toJSON().error){
+          cb(null, true);
+        } else {
+          cb(d.toJSON().error, false);
+        }
+      })
+    });
   });
 }
 


### PR DESCRIPTION
Relies on changes to auth server here https://github.com/tessel/oauth/compare/es-add-proxy-token, which exposes a route for the proxy server to check if the credentials are valid. 

This is branched off of the simple-start branch, and modifies the [checkCredentials function](https://github.com/tessel/proxy/blob/es-add-auth/lib/token-server.js#L8) to send a request to the auth server before issuing the proxy token.

@natevw something like this what you had in mind?
