### PR TITLE
Drop unneeded client_id parameter

### DIFF
--- a/proxy-auth.js
+++ b/proxy-auth.js
@@ -7,14 +7,12 @@ if (AUTH_TESSEL_OA2) {
   var url = require('url'),
       fermata = require('fermata'),
       oa2_url = url.parse(AUTH_TESSEL_OA2),
-      client_id = oa2_url.auth.split(':')[0],
       token_api = fermata.json(AUTH_TESSEL_OA2)('oauth', 'token'),
       profile_api = delete oa2_url.auth && fermata.json(url.format(oa2_url))('users', 'profile');
   module.exports = function (token, cb) {
     token_api.post({'Content-Type':"application/x-www-form-urlencoded"}, {
       grant_type: "https://tessel-grant",
-      api_key: token,
-      client_id: client_id
+      api_key: token
     }, function (e,d) {
       if (e && e.status === 400) cb(null, null);
       else if (e) cb(e);


### PR DESCRIPTION
NOTE: depends on https://github.com/tessel/oauth/pull/36 getting deployed to production oauth server.